### PR TITLE
Api/고정수업지출조회등록삭제

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,30 @@
+const http = require('http');
+const express = require('express');
+const cors = require('cors');
+const dotenv = require('dotenv');
+const routes = require('./src/routes');
+const app = express()
+
+dotenv.config()
+app.use(cors())
+app.use(express.json())
+app.use(routes)
+
+app.get('/ping',(req,res) => {
+  res.status(200).json({
+    message: 'pong'
+  })
+})
+
+const server = http.createServer(app)
+
+const start = async () => {
+  try {
+    server.listen(process.env.TYPEORM_SERVER_PORT, () => console.log(
+      `Server is listening on ${process.env.TYPEORM_SERVER_PORT}`))
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+start()

--- a/src/controllers/fixedMoneyFlowController.js
+++ b/src/controllers/fixedMoneyFlowController.js
@@ -1,0 +1,28 @@
+const fixedFlowService = require('../services/fixedMoneyFlowService');
+const categoryService = require('../services/categoryService');
+const error = require('../utils/error');
+
+const postFixedFlows = async (req, res) => { // 관리자만 가능
+  try {
+    const { userId, familyId, roleId } = req.userData;
+    if (!familyId || !roleId) {
+      error.throwErr(400, 'NOT_INCLUDED_IN_FAMILY_OR_NOT_AN_ADMIN');
+    }
+    const { type, category, memo, amount, startYear, startMonth, startDate, endYear, endMonth } = req.body;
+    if ( !type || !category || !memo || !amount || !startYear || !startMonth || !startDate || !endYear || !endMonth) {
+      error.throwErr(400, 'KEY ERROR');
+    }
+    const categoryId = await categoryService.getIdByCategoryName(category);
+    const fixedMoneyFlowIds = await fixedFlowService.postFixedMoneyFlows(userId, type, categoryId, memo, amount, startYear, startMonth, startDate, endYear, endMonth);
+    const fixedMoneyFlowsGroupId = await fixedFlowService.postFixedMoneyFlowsGroup();
+    await fixedFlowService.postMiddleFixedMoneyFlows(fixedMoneyFlowIds, fixedMoneyFlowsGroupId);
+    return res.status(200).json({message: 'POST_SUCCESS'});
+  } catch (err) {
+    console.error(err);
+    return res.status(err.statusCode || 500).json({message: err.message || 'INTERNAL_SERVER_ERROR'});
+  }
+}
+
+module.exports = {
+  postFixedFlows
+}

--- a/src/controllers/fixedMoneyFlowController.js
+++ b/src/controllers/fixedMoneyFlowController.js
@@ -1,4 +1,5 @@
 const fixedFlowService = require('../services/fixedMoneyFlowService');
+const userService = require('../services/userService');
 const categoryService = require('../services/categoryService');
 const error = require('../utils/error');
 
@@ -23,6 +24,21 @@ const postFixedFlows = async (req, res) => { // 관리자만 가능
   }
 }
 
+const getFixedMoneyFlows = async (req, res) => {
+  try {
+    const { userId, familyId, roleId } = req.userData;
+    if (!familyId || !roleId) {
+      error.throwErr(400, 'NOT_INCLUDED_IN_FAMILY_OR_NOT_AN_ADMIN');
+    }
+    const fixedMoneyFlows = await fixedFlowService.getFixedMoneyFlows(userId);
+    return res.status(200).json({message: 'GET_SUCCESS', fixedFlow: await fixedMoneyFlows});
+    } catch (err) {
+      console.error(err);
+      return res.status(err.statusCode || 500).json({message: err.message || 'INTERNAL_SERVER_ERROR'});
+    }
+}
+
 module.exports = {
-  postFixedFlows
+  postFixedFlows,
+  getFixedMoneyFlows
 }

--- a/src/controllers/fixedMoneyFlowController.js
+++ b/src/controllers/fixedMoneyFlowController.js
@@ -31,7 +31,7 @@ const getFixedMoneyFlows = async (req, res) => {
       error.throwErr(400, 'NOT_INCLUDED_IN_FAMILY_OR_NOT_AN_ADMIN');
     }
     const fixedMoneyFlows = await fixedFlowService.getFixedMoneyFlows(userId);
-    return res.status(200).json({message: 'GET_SUCCESS', fixedFlow: await fixedMoneyFlows});
+    return res.status(200).json({message: 'GET_SUCCESS', fixedFlow: fixedMoneyFlows});
     } catch (err) {
       console.error(err);
       return res.status(err.statusCode || 500).json({message: err.message || 'INTERNAL_SERVER_ERROR'});

--- a/src/models/categoryDao.js
+++ b/src/models/categoryDao.js
@@ -11,6 +11,18 @@ const getIdByCategoryName = async (category) => {
   )
 }
 
+const getNameById = async (categoryId) => {
+  return await appDataSource.query(
+    `
+    SELECT category 
+    FROM categories 
+    WHERE id = ?
+    `,
+    [categoryId]
+  )
+}
+
 module.exports = {
-  getIdByCategoryName
+  getIdByCategoryName,
+  getNameById
 }

--- a/src/models/categoryDao.js
+++ b/src/models/categoryDao.js
@@ -1,0 +1,16 @@
+const { appDataSource } = require('../utils/dataSource');
+
+const getIdByCategoryName = async (category) => {
+  return await appDataSource.query(
+    `
+    SELECT id as categoryId 
+    FROM categories
+    WHERE category = ? 
+    `,
+    [category]
+  )
+}
+
+module.exports = {
+  getIdByCategoryName
+}

--- a/src/models/fixedMoneyFlowDao.js
+++ b/src/models/fixedMoneyFlowDao.js
@@ -44,8 +44,22 @@ const postMiddleFixedMoneyFlow = async (fixedMoneyFlowId, fixedMoneyFlowsGroupId
   return result;
 }
 
+const getFixedMoneyFlows = async(userId) => { // flow_type_id가 1이면 수입, 2이면 지출입니다.
+  console.log(userId)
+  return await appDataSource.query(
+    `
+    SELECT id, user_id, flow_type_id, category_id, memo, amount, year, month, date 
+    FROM fixed_money_flows 
+    WHERE user_id = ?
+    ORDER BY year DESC, month DESC, date DESC, amount DESC, flow_type_id, category_id
+    `,
+    [ userId ]
+  )
+}
+
 module.exports = {
   postFixedMoneyFlow,
   postFixedMoneyFlowsGroup,
-  postMiddleFixedMoneyFlow
+  postMiddleFixedMoneyFlow,
+  getFixedMoneyFlows
 }

--- a/src/models/fixedMoneyFlowDao.js
+++ b/src/models/fixedMoneyFlowDao.js
@@ -1,0 +1,51 @@
+const { appDataSource } = require('../utils/dataSource');
+const error = require('../utils/error');
+
+const postFixedMoneyFlow = async (userId, typeId, categoryId, memo, amount, year, month, date) => {
+  const result = await appDataSource.query(
+    `
+    INSERT INTO fixed_money_flows(user_id, flow_type_id, category_id, memo, amount, year, month, date)
+    VALUES(?,?,?,?,?,?,?,?)
+    `,
+    [userId, typeId, categoryId, memo, amount, year, month, date]
+  )
+  if (result.insertId === 0) {
+    error.throwErr(500, 'DATA_INSERTION_FAILED');
+  }
+  return result.insertId;
+}
+
+const postFixedMoneyFlowsGroup = async () => {
+  const result = await appDataSource.query(
+    `
+    INSERT INTO fixed_money_flows_group() 
+    VALUES ();
+    `
+  )
+  const mysqlId = result.insertId;
+  if (mysqlId === 0) {
+    error.throwErr(500, 'DATA_INSERTION_FAILED');
+  }
+  return mysqlId;
+}
+
+const postMiddleFixedMoneyFlow = async (fixedMoneyFlowId, fixedMoneyFlowsGroupId) => {
+  const result = await appDataSource.query(
+    `
+    INSERT INTO middle_fixed_money_flows(fixed_money_flow_id, fixed_money_flow_group_id) 
+    VALUES(?,?)
+    `,
+    [fixedMoneyFlowId, fixedMoneyFlowsGroupId]
+  )
+  const mysqlId = result.insertId;
+  if (mysqlId === 0) {
+    error.throwErr(500, 'DATA_INSERTION_FAILED');
+  }
+  return result;
+}
+
+module.exports = {
+  postFixedMoneyFlow,
+  postFixedMoneyFlowsGroup,
+  postMiddleFixedMoneyFlow
+}

--- a/src/models/flowTypeDao.js
+++ b/src/models/flowTypeDao.js
@@ -1,0 +1,16 @@
+const { appDataSource } = require('../utils/dataSource');
+
+const getFlowStatusById = async (flowTypeId) => {
+  return await appDataSource.query(
+    `
+    SELECT status 
+    FROM flow_type 
+    WHERE id = ?
+    `,
+    [flowTypeId]
+  )
+}
+
+module.exports = {
+  getFlowStatusById
+}

--- a/src/models/userDao.js
+++ b/src/models/userDao.js
@@ -1,0 +1,43 @@
+const { appDataSource } = require('../utils/dataSource');
+const getUserByEmail = async(email) => {
+  return await appDataSource.query(
+    `
+    SELECT *
+    FROM users
+    WHERE email = ?
+    `,
+    [email]
+  )
+};
+
+const getUserInformationById = async( userId ) => {
+  const [ result ] = await appDataSource.query(
+    `
+    SELECT
+    id AS userId
+    FROM users
+    WHERE id = ?
+    `,
+    [ userId ])
+  const [ result1 ] = await appDataSource.query(
+    `
+    SELECT
+    u.id AS userId,
+    uf.family_id AS familyId,
+    role_id AS roleId
+    FROM users u
+    JOIN users_families uf ON u.id = uf.user_id
+    WHERE u.id = ?
+    `,
+    [ userId ])
+  if (!result1) {
+    return result;
+  } else {
+    return result1;
+  }
+}
+
+module.exports = {
+  getUserByEmail,
+  getUserInformationById
+}

--- a/src/models/userDao.js
+++ b/src/models/userDao.js
@@ -37,7 +37,19 @@ const getUserInformationById = async( userId ) => {
   }
 }
 
+const getNameById = async (userId) => {
+  return await appDataSource.query(
+    `
+    SELECT name
+    FROM users 
+    WHERE user_id = ?
+    `,
+    [userId]
+  )
+}
+
 module.exports = {
   getUserByEmail,
-  getUserInformationById
+  getUserInformationById,
+  getNameById
 }

--- a/src/routes/fixedMoneyFlowRouter.js
+++ b/src/routes/fixedMoneyFlowRouter.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const fixedMoneyFlowController = require('../controllers/fixedMoneyFlowController');
+
+const { loginRequired } = require('../utils/auth');
+router.post('/', loginRequired, fixedMoneyFlowController.postFixedFlows);
+
+module.exports.router = router;

--- a/src/routes/fixedMoneyFlowRouter.js
+++ b/src/routes/fixedMoneyFlowRouter.js
@@ -3,6 +3,8 @@ const router = express.Router();
 const fixedMoneyFlowController = require('../controllers/fixedMoneyFlowController');
 
 const { loginRequired } = require('../utils/auth');
+
+router.get('/', loginRequired, fixedMoneyFlowController.getFixedMoneyFlows);
 router.post('/', loginRequired, fixedMoneyFlowController.postFixedFlows);
 
 module.exports.router = router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+
+const fixedMoneyFlowRouter = require('./fixedMoneyFlowRouter');
+
+router.use('/flow/fixed', fixedMoneyFlowRouter.router);
+
+module.exports = router;

--- a/src/services/categoryService.js
+++ b/src/services/categoryService.js
@@ -6,6 +6,12 @@ const getIdByCategoryName = async (category) => {
   return await result[0]['categoryId'];
 }
 
+const getNameById = async (categoryId) => {
+  const result = await categoryDao.getNameById(categoryId);
+  return result[0]['category'];
+}
+
 module.exports = {
-  getIdByCategoryName
+  getIdByCategoryName,
+  getNameById
 }

--- a/src/services/categoryService.js
+++ b/src/services/categoryService.js
@@ -1,0 +1,11 @@
+const categoryDao = require('../models/categoryDao');
+const error = require('../utils/error');
+
+const getIdByCategoryName = async (category) => {
+  const result = await categoryDao.getIdByCategoryName(category);
+  return await result[0]['categoryId'];
+}
+
+module.exports = {
+  getIdByCategoryName
+}

--- a/src/services/fixedMoneyFlowService.js
+++ b/src/services/fixedMoneyFlowService.js
@@ -1,0 +1,70 @@
+const fixedFlowDao = require('../models/fixedMoneyFlowDao');
+const error = require('../utils/error');
+
+const postFixedMoneyFlows = async (userId, type, categoryId, memo, amount, startYear, startMonth, startDate, endYear, endMonth) => {
+  let typeId = 1;
+  switch (type) {
+    case '수입':
+      break;
+    case '지출':
+      typeId += 1;
+      break;
+    default:
+      console.log('어떤 값인지 파악이 되지 않습니다.');
+  }
+  const integerStartYear = parseInt(startYear);
+  const integerStartMonth = parseInt(startMonth);
+  const integerStartDate = parseInt(startDate);
+  const integerEndYear = parseInt(endYear);
+  const integerEndMonth = parseInt(endMonth);
+  const result = []; // 결과값
+  if (integerEndYear - integerStartYear > 0) {
+    for (let k = integerStartYear; k <= integerEndYear; k++) {
+      if (k === integerStartYear) {
+        for (let i = integerStartMonth; i <= 12; i++) {
+          result.push(await fixedFlowDao.postFixedMoneyFlow(userId, typeId, categoryId, memo, amount, k, i, integerStartDate));
+        }
+      }
+      else if (integerStartYear < k < integerEndYear) {
+        for (let l = 1; l <= 12; l++) {
+          result.push(await fixedFlowDao.postFixedMoneyFlow(userId, typeId, categoryId, memo, amount, k, l, integerStartDate));
+        }
+      }
+      for (let n = 1; n <= integerEndMonth; n++) {
+        result.push(await fixedFlowDao.postFixedMoneyFlow(userId, typeId, categoryId, memo, amount, k, n, integerStartDate));
+      }
+    }
+  }
+  else if (integerEndYear === integerStartYear) {
+    if (endMonth > integerStartMonth) {
+      for (let m = integerStartMonth; m <= integerEndMonth; m++) {
+        result.push(await fixedFlowDao.postFixedMoneyFlow(userId, typeId, categoryId, memo, amount, integerStartYear, m, integerStartDate));
+      }
+    }
+    else {
+      error.throwErr(400, '마감월은 시작월보다 뒤여야 합니다');
+    }
+  }
+  else if (integerEndYear < integerStartYear) {
+    error.throwErr(400, '마감년도는 시작년도 이후여야 합니다');
+  }
+  // console.log(result);
+  return result; // 결과값을 반환합니다. fixed_money_flows 에 POST 한 id 값들의 모음입니다.
+}
+
+const postFixedMoneyFlowsGroup = async () => {
+  return await fixedFlowDao.postFixedMoneyFlowsGroup(); // Dao 에서 만든 fixed_money_flows_group 의 insertId를 반환합니다.
+}
+
+const postMiddleFixedMoneyFlows = async (fixedMoneyFlowIds, fixedMoneyFlowsGroupId) => {
+  for (let i = 0; i < fixedMoneyFlowIds.length; i++) {
+    await fixedFlowDao.postMiddleFixedMoneyFlow(fixedMoneyFlowIds[i], fixedMoneyFlowsGroupId);
+  }
+  return "SUCCESS";
+}
+
+module.exports = {
+  postFixedMoneyFlows,
+  postFixedMoneyFlowsGroup,
+  postMiddleFixedMoneyFlows
+}

--- a/src/services/fixedMoneyFlowService.js
+++ b/src/services/fixedMoneyFlowService.js
@@ -67,7 +67,6 @@ const postMiddleFixedMoneyFlows = async (fixedMoneyFlowIds, fixedMoneyFlowsGroup
 
 const getFixedMoneyFlows = async (userId) => {
   const flows = await fixedMoneyFlowDao.getFixedMoneyFlows(userId);
-  console.log(flows)
   const mapped = await Promise.all(flows.map( async (flow) => ({
       id: flow.id,
       userName: await userService.getNameById(flow.user_id),

--- a/src/services/flowTypeService.js
+++ b/src/services/flowTypeService.js
@@ -1,0 +1,10 @@
+const flowTypeDao = require('../models/flowTypeDao');
+
+const getFlowStatusById = async (flowTypeId) => {
+  const result = await flowTypeDao.getFlowStatusById(flowTypeId);
+  return result[0].status;
+}
+
+module.exports = {
+  getFlowStatusById
+}

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,0 +1,10 @@
+const userDao = require('../models/categoryDao');
+
+const getNameById = async (userId) => {
+  const result = await userDao.getIdByCategoryName(userId);
+  return result[0];
+}
+
+module.exports = {
+  getNameById
+}

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,28 @@
+const jwt = require('jsonwebtoken');
+const userDao = require('../models/userDao');
+const error = require('./error');
+const secretKey = process.env.SECRET_KEY
+
+const loginRequired = async (req, res, next) => {
+  try {
+    const accessToken = req.headers.authorization.substr(7);
+    if (!accessToken) {
+      error.throwErr(401, 'NEEDED_ACCESS_TOKEN');
+    }
+    const payload = jwt.verify(accessToken, secretKey);
+    const [ user ] = await userDao.getUserByEmail(payload.email);
+    if (!user) {
+      error.throwErr(404, 'USER_DOES_NOT_EXIST');
+    }
+    req.user = user;
+    const userInfo = await userDao.getUserInformationById( user.id );
+    req.userData = userInfo;
+    next();
+  } catch(err) {
+    res.status(err.statusCode || 500).json({message: err.message || 'INTERNAL_SERVER_ERROR'})
+  }
+}
+
+module.exports = {
+  loginRequired
+}

--- a/src/utils/dataSource.js
+++ b/src/utils/dataSource.js
@@ -1,0 +1,24 @@
+const { DataSource } = require('typeorm');
+const dotenv = require('dotenv')
+dotenv.config()
+
+const appDataSource = new DataSource({
+  type : process.env.TYPEORM_CONNECTION,
+  host: process.env.TYPEORM_HOST,
+  port: process.env.TYPEORM_PORT,
+  username: process.env.TYPEORM_USERNAME,
+  password: process.env.TYPEORM_PASSWORD,
+  database: process.env.TYPEORM_DATABASE
+})
+
+appDataSource.initialize()
+  .then(() => {
+    console.log('Data Source has been initialized!')
+  })
+  .catch((err) => {
+    console.error('Error occured during Data Source initialization', err)
+  })
+
+module.exports = {
+  appDataSource
+}

--- a/src/utils/error.js
+++ b/src/utils/error.js
@@ -1,0 +1,9 @@
+const throwErr = (code, message) => {
+  const error = new Error(message);
+  error.status = code;
+  throw error;
+};
+
+module.exports = {
+  throwErr
+}


### PR DESCRIPTION
## 1. 본 PR이 우리 팀의 웹 서비스 제품성에 어떠한 기여를 하였고, <br> 사용자에게 어떠한 기대효과를 전달하는지 작성해주세요.

- 내 PR이 제품 내 어떠한 기능적인 배경/전후맥락 가운데 개발되었나요?

  - 관리자는 가족이 쓸 수 있는 특정 연, 월의 총 예산을 설정(등록)하고 조회, 수정 및 삭제할 수 있습니다. (등록, 수정, 삭제는 관리자 권한)
  
- 내 PR이 Merge 됨으로써 유저에게 전달되는 편익/기대효과는 무엇일까요?

  - 가족 단위로 max 소비 금액을 지표로 모든 가족에게 알려 주어, 해당 월의 예산과 지출을 비교하면 예산 비례 소비량 등과 같은 지표를
     제공할 수 있습니다.
  - 현재 예산 삭제는 기능을 사용자에게 제공할 지는 미정이지만 가능한 node api 및 uri는 만들어 두었습니다.
<br />

## 2. 이 브랜치에서 어떤 내용을 개발했는지 큰 제목과 상세 내역을 적어주세요.

(예시) 로그인 기능 추가

- 관리자만이 예산 등록(연, 월, 금액)을 등록할 수 있으며, 같은 연 월에 예산을 총 여러 개 등록되게 할 수는 없습니다.
- 관리자만 예산에 대한 데이터 수정이 가능합니다.
- 예산은 연, 월 변동 시 중복 방지를 위해 수정 기능은 예산 금액만 수정할 수 있도록 node에서 db의 예산의 연, 월을
  서버 자체적으로 수정하지 못하도록(예산 데이터 자체 삭제는 서버의 함수로 가능하나 연, 월에 대한 수정은 불가) 사전에 구성해 두었습니다.

<br />

## 3. 개발한 화면을 캡쳐해서 첨부 해 주세요. 

<br />
![스크린샷 2023-11-17 오전 6 51 07](https://github.com/wecode-bootcamp-korea/50-3rd-Fin_Pong-backend/assets/82556127/bcadb46b-7362-4e68-9550-6a2978ae2e81)

<img width="1453" alt="스크린샷 2023-11-17 오전 6 52 49" src="https://github.com/wecode-bootcamp-korea/50-3rd-Fin_Pong-backend/assets/82556127/6c2b8117-8bf5-4901-9b82-6cfc5346c654">

<br />

## 4. 이 브랜치에서 개발하면서 느꼇던 개발 성장포인트를 적어주세요.

- frontend Browser에서 id 값이나 수정 전 후의 값을 알려준다면, 연, 월을 수정하게 하고 db에서 error handling을 할 수 있지 않을까 합니다  - (db의 정확히 어느 id의 예산을 수정하려 하는 건지, 수정 전 값(연, 월), 수정 목표 값(연, 월) 멱등성 문제) 
- html 태그를 타고 특정 value 값으로 들어가는 것, caching 등 외엔 딱히 방법이 없어 보여 node에서는 해결할 방법이 있는 지
  더 알아보려 합니다.
  <br />
